### PR TITLE
CVN-96 Update calls to network_of_terms_client's functions

### DIFF
--- a/models/m_network_of_terms.erl
+++ b/models/m_network_of_terms.erl
@@ -11,14 +11,14 @@
 
 -behaviour(gen_model).
 
-m_find_value(sources, #m{}, _Context) ->
-    network_of_terms_client:get_sources();
+m_find_value(sources, #m{}, Context) ->
+    network_of_terms_client:get_sources(Context);
 m_find_value(Uri, #m{}, Context) when not is_binary(Uri) ->
     m_find_value(z_convert:to_binary(Uri), #m{}, Context);
 m_find_value(Uri, #m{}, Context) when is_binary(Uri) ->
     z_depcache:memo(
         fun() ->
-            [Result] = network_of_terms_client:lookup([Uri]),
+            [Result] = network_of_terms_client:lookup([Uri], Context),
             lookup_result(Result)
         end,
         {term, Uri},


### PR DESCRIPTION
Problem: In ae268b0eff8a335d8e0f2cb3b3e647e9adef0020 the arity of the functions in network_of_terms_client has changed to support ACL checks, but not all the calls to these functions made from m_network_of_terms have been updated, causing failures.

Solution: Update function calls to pass the necessary context.